### PR TITLE
[ODS-4807] PostgreSQL migration to 5.0.0 is losing some auth views

### DIFF
--- a/EdFi.Ods.Utilities.Migration.Tests/appsettings.pgsql.json
+++ b/EdFi.Ods.Utilities.Migration.Tests/appsettings.pgsql.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "EdFi_Ods_Migration_Test": "host=localhost;port=5432;username=postgres;database=EdFi_Ods_Migration_Test;pooling=true;Minimum Pool Size=10;Maximum Pool Size=50;client encoding=utf-8;command timeout=300",
+    "EdFi_Ods_Migration_Test": "host=localhost;port=5432;username=postgres;database=EdFi_Ods_Migration_Test;pooling=true;Minimum Pool Size=10;Maximum Pool Size=50;client encoding=utf-8;command timeout=600",
     "RestoreBackupOnly": "host=localhost;port=5432;username=postgres;database=postgres;pooling=false;client encoding=utf-8"
   },
   "GrandBendBackupPathsByDisplayName": {


### PR DESCRIPTION
auth.educationorganizationidtostateagencyid  and auth.educationorganizationidtoeducationservicecenterid both views are dependency of another view auth.EducationOrganizationIdentifiers.
we have CASCADE on droping VIEW IF EXISTS for  auth.EducationOrganizationIdentifiers  .so it deletes the auth.educationorganizationidtostateagencyid and auth.educationorganizationidtoeducationservicecenterid both views from database.
And also creating views is missing for auth.educationorganizationidtostateagencyid and auth.educationorganizationidtoeducationservicecenterid both views in scripts . 
CASCADE will delete dependency view also when you delete the particular view .

Now I added the dependency views also in this defect fix