### PR TITLE
[ODS-4806] PostgreSQL migration to 5.1.0 is losing some auth views

### DIFF
--- a/EdFi.Ods.Utilities.Migration/Scripts/PgSql/02Upgrade/v50_to_v51/01 Structure/1210-UpdateViewsForV51.sql
+++ b/EdFi.Ods.Utilities.Migration/Scripts/PgSql/02Upgrade/v50_to_v51/01 Structure/1210-UpdateViewsForV51.sql
@@ -3,7 +3,10 @@
 -- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 -- See the LICENSE and NOTICES files in the project root for more information.
 
-DROP VIEW IF EXISTS auth.CommunityProviderIdToStaffUSI CASCADE;
+-- Drop dependent views
+DROP VIEW IF EXISTS auth.EducationOrganizationIdToStaffUSI;
+
+DROP VIEW IF EXISTS auth.CommunityProviderIdToStaffUSI ;
 
 CREATE VIEW auth.CommunityProviderIdToStaffUSI
 AS
@@ -83,7 +86,7 @@ AS
             ON psi.PostSecondaryInstitutionId = assgn.EducationOrganizationId;
 
 
-DROP VIEW IF EXISTS auth.SchoolIdToStaffUSI CASCADE;
+DROP VIEW IF EXISTS auth.SchoolIdToStaffUSI ;
 
 CREATE VIEW auth.SchoolIdToStaffUSI
 AS
@@ -102,4 +105,18 @@ AS
     FROM edfi.School sch
         INNER JOIN edfi.StaffEducationOrganizationAssignmentAssociation seo_assgn
             ON sch.SchoolId = seo_assgn.EducationOrganizationId;
+
+-- Recreate dependent views
+CREATE VIEW auth.EducationOrganizationIdToStaffUSI
+AS
+    SELECT SchoolId AS EducationOrganizationId
+         ,StaffUSI
+    FROM auth.SchoolIdToStaffUSI
+
+    UNION ALL
+
+    SELECT LocalEducationAgencyId AS EducationOrganizationId
+         ,StaffUSI
+    FROM auth.LocalEducationAgencyIdToStaffUSI;
+
 


### PR DESCRIPTION
auth.educationorganizationidtostaffusi both views are dependency of another view auth.CommunityProviderIdToStaffUSI.
we have CASCADE on droping VIEW IF EXISTS for auth.CommunityProviderIdToStaffUSI.so it deletes the auth.educationorganizationidtostaffusi views from database.
And also creating views is missing for auth.educationorganizationidtostaffusi  in scripts .
CASCADE will delete dependency view also when you delete the particular view .

Now I added the dependency views also in this defect fix

Note :auth.SchoolIdToStaffUSI view also depend on auth.educationorganizationidtostaffusi 