### PR TITLE
ODS-5215 - Add DeployJournal scripts for change feature in v53

### DIFF
--- a/EdFi.Ods.Utilities.Migration.Tests/MsSql/MigrationTests/all_versions/SqlServerV52ToV53JournalTests.cs
+++ b/EdFi.Ods.Utilities.Migration.Tests/MsSql/MigrationTests/all_versions/SqlServerV52ToV53JournalTests.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Collections.Generic;
 using EdFi.Ods.Utilities.Migration.Enumerations;
 using EdFi.Ods.Utilities.Migration.Tests.Enumerations;
 using EdFi.Ods.Utilities.Migration.Tests.MsSql.MigrationTests.v52_to_v53;
@@ -16,5 +17,6 @@ namespace EdFi.Ods.Utilities.Migration.Tests.MsSql.MigrationTests.all_versions
         protected override DatabaseRestoreSetupOption DatabaseRestoreSetupOption { get; } = DatabaseRestoreSetupOption.FullRestoreBeforeEveryTest;
         protected override EdFiOdsVersion FromVersion => EdFiOdsVersion.V52;
         protected override EdFiOdsVersion ToVersion => EdFiOdsVersion.V53;
+        protected override List<EdFiOdsFeature> FeaturesBeforeUpgrade => new List<EdFiOdsFeature> { EdFiOdsFeature.ChangeQueries };
     }
 }

--- a/EdFi.Ods.Utilities.Migration.Tests/PgSql/MigrationTests/all_versions/PostgreSqlV52ToV53JournalTests.cs
+++ b/EdFi.Ods.Utilities.Migration.Tests/PgSql/MigrationTests/all_versions/PostgreSqlV52ToV53JournalTests.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Collections.Generic;
 using EdFi.Ods.Utilities.Migration.Enumerations;
 using EdFi.Ods.Utilities.Migration.Tests.Enumerations;
 using EdFi.Ods.Utilities.Migration.Tests.PgSql.MigrationTests.v52_to_v53;
@@ -16,5 +17,6 @@ namespace EdFi.Ods.Utilities.Migration.Tests.PgSql.MigrationTests.all_versions
         protected override DatabaseRestoreSetupOption DatabaseRestoreSetupOption { get; } = DatabaseRestoreSetupOption.FullRestoreBeforeEveryTest;
         protected override EdFiOdsVersion FromVersion => EdFiOdsVersion.V52;
         protected override EdFiOdsVersion ToVersion => EdFiOdsVersion.V53;
+        protected override List<EdFiOdsFeature> FeaturesBeforeUpgrade => new List<EdFiOdsFeature> { EdFiOdsFeature.ChangeQueries };
     }
 }

--- a/EdFi.Ods.Utilities.Migration/Scripts/MsSql/02Upgrade/v52_to_v53_Changes/03 DeployJournal/v53FeaturesUpdateDeployJournal.sql
+++ b/EdFi.Ods.Utilities.Migration/Scripts/MsSql/02Upgrade/v52_to_v53_Changes/03 DeployJournal/v53FeaturesUpdateDeployJournal.sql
@@ -1,0 +1,31 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+DECLARE @EdFiDeployJournal TABLE
+(
+[ScriptName] [nvarchar] (255) NOT NULL
+)
+
+INSERT @EdFiDeployJournal (ScriptName)
+VALUES
+('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.0010-CreateChangesSchema.sql'),
+('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.0020-CreateChangeVersionSequence.sql'),
+('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.0030-AddColumnChangeVersionForTables.sql'),
+('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.0040-CreateTriggerUpdateChangeVersionGenerator.sql'),
+('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.0045-CreateTrackedDeleteSchema.sql'),
+('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.0050-CreateTrackedDeleteTables.sql'),
+('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.0060-CreateDeletedForTrackingTriggers.sql'),
+('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.0070-AddIndexChangeVersionForTables.sql'),
+('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.0110-AddSnapshot-Tables.sql'),
+('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.0120-AddSnapshotIdColumnUniqueIndexes.sql'),
+('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.0130-AddSnapshotExtendedProperties.sql'),
+('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.1010-CreateGetMaxChangeVersionFunction.sql')
+
+INSERT [dbo].[DeployJournal] ([ScriptName], [Applied])
+SELECT e.[ScriptName], GETDATE()
+FROM @EdFiDeployJournal e
+LEFT JOIN [dbo].[DeployJournal] dj
+    ON e.[ScriptName] = dj.[ScriptName]
+WHERE dj.[ScriptName] IS NULL

--- a/EdFi.Ods.Utilities.Migration/Scripts/MsSql/02Upgrade/v52_to_v53_Changes/03 DeployJournal/v53FeaturesUpdateDeployJournal.sql
+++ b/EdFi.Ods.Utilities.Migration/Scripts/MsSql/02Upgrade/v52_to_v53_Changes/03 DeployJournal/v53FeaturesUpdateDeployJournal.sql
@@ -21,7 +21,9 @@ VALUES
 ('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.0110-AddSnapshot-Tables.sql'),
 ('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.0120-AddSnapshotIdColumnUniqueIndexes.sql'),
 ('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.0130-AddSnapshotExtendedProperties.sql'),
-('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.1010-CreateGetMaxChangeVersionFunction.sql')
+('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.1010-CreateGetMaxChangeVersionFunction.sql'),
+('Edfi.Ods.Standard.Artifacts.Mssql.Structure.Ods.Changes.1060-AddNewDeleteTablesForV53.sql'),
+('Edfi.Ods.Standard.Artifacts.Mssql.Structure.Ods.Changes.1070-CreateDeletedForTrackingTriggersForV53.sql')
 
 INSERT [dbo].[DeployJournal] ([ScriptName], [Applied])
 SELECT e.[ScriptName], GETDATE()

--- a/EdFi.Ods.Utilities.Migration/Scripts/MsSql/02Upgrade/v52_to_v53_Changes/03 DeployJournal/v53FeaturesUpdateDeployJournal.sql
+++ b/EdFi.Ods.Utilities.Migration/Scripts/MsSql/02Upgrade/v52_to_v53_Changes/03 DeployJournal/v53FeaturesUpdateDeployJournal.sql
@@ -21,9 +21,7 @@ VALUES
 ('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.0110-AddSnapshot-Tables.sql'),
 ('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.0120-AddSnapshotIdColumnUniqueIndexes.sql'),
 ('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.0130-AddSnapshotExtendedProperties.sql'),
-('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.1010-CreateGetMaxChangeVersionFunction.sql'),
-('Edfi.Ods.Standard.Artifacts.Mssql.Structure.Ods.Changes.1060-AddNewDeleteTablesForV53.sql'),
-('Edfi.Ods.Standard.Artifacts.Mssql.Structure.Ods.Changes.1070-CreateDeletedForTrackingTriggersForV53.sql')
+('EdFi.Ods.Standard.Artifacts.MsSql.Structure.Ods.Changes.1010-CreateGetMaxChangeVersionFunction.sql')
 
 INSERT [dbo].[DeployJournal] ([ScriptName], [Applied])
 SELECT e.[ScriptName], GETDATE()

--- a/EdFi.Ods.Utilities.Migration/Scripts/PgSql/02Upgrade/v52_to_v53_Changes/03 DeployJournal/v53FeaturesUpdateDeployJournal.sql
+++ b/EdFi.Ods.Utilities.Migration/Scripts/PgSql/02Upgrade/v52_to_v53_Changes/03 DeployJournal/v53FeaturesUpdateDeployJournal.sql
@@ -20,7 +20,9 @@ VALUES
 ('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.0110-AddSnapshot-Tables.sql'),
 ('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.0120-AddSnapshotIdColumnUniqueIndexes.sql'),
 ('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.0130-AddSnapshotExtendedProperties.sql'),
-('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.1010-CreateGetMaxChangeVersionFunction.sql');
+('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.1010-CreateGetMaxChangeVersionFunction.sql'),
+('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.1060-AddNewDeleteTablesForV53.sql'),
+('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.1070-CreateDeletedForTrackingTriggersForV53.sql');
 
 INSERT INTO public."DeployJournal" (scriptname, applied)
 SELECT e.scriptname, NOW()

--- a/EdFi.Ods.Utilities.Migration/Scripts/PgSql/02Upgrade/v52_to_v53_Changes/03 DeployJournal/v53FeaturesUpdateDeployJournal.sql
+++ b/EdFi.Ods.Utilities.Migration/Scripts/PgSql/02Upgrade/v52_to_v53_Changes/03 DeployJournal/v53FeaturesUpdateDeployJournal.sql
@@ -20,9 +20,7 @@ VALUES
 ('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.0110-AddSnapshot-Tables.sql'),
 ('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.0120-AddSnapshotIdColumnUniqueIndexes.sql'),
 ('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.0130-AddSnapshotExtendedProperties.sql'),
-('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.1010-CreateGetMaxChangeVersionFunction.sql'),
-('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.1060-AddNewDeleteTablesForV53.sql'),
-('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.1070-CreateDeletedForTrackingTriggersForV53.sql');
+('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.1010-CreateGetMaxChangeVersionFunction.sql');
 
 INSERT INTO public."DeployJournal" (scriptname, applied)
 SELECT e.scriptname, NOW()

--- a/EdFi.Ods.Utilities.Migration/Scripts/PgSql/02Upgrade/v52_to_v53_Changes/03 DeployJournal/v53FeaturesUpdateDeployJournal.sql
+++ b/EdFi.Ods.Utilities.Migration/Scripts/PgSql/02Upgrade/v52_to_v53_Changes/03 DeployJournal/v53FeaturesUpdateDeployJournal.sql
@@ -1,0 +1,30 @@
+-- SPDX-License-Identifier: Apache-2.0
+-- Licensed to the Ed-Fi Alliance under one or more agreements.
+-- The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+-- See the LICENSE and NOTICES files in the project root for more information.
+
+CREATE TEMP TABLE EdFiDeployJournal (
+ScriptName VARCHAR(255) NOT NULL
+);
+
+INSERT INTO EdFiDeployJournal (ScriptName)
+VALUES
+('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.0010-CreateChangesSchema.sql'),
+('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.0020-CreateChangeVersionSequence.sql'),
+('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.0030-AddColumnChangeVersionForTables.sql'),
+('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.0040-CreateTriggerUpdateChangeVersionGenerator.sql'),
+('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.0045-CreateTrackedDeleteSchema.sql'),
+('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.0050-CreateTrackedDeleteTables.sql'),
+('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.0060-CreateDeletedForTrackingTriggers.sql'),
+('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.0070-AddIndexChangeVersionForTables.sql'),
+('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.0110-AddSnapshot-Tables.sql'),
+('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.0120-AddSnapshotIdColumnUniqueIndexes.sql'),
+('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.0130-AddSnapshotExtendedProperties.sql'),
+('EdFi.Ods.Standard.Artifacts.PgSql.Structure.Ods.Changes.1010-CreateGetMaxChangeVersionFunction.sql');
+
+INSERT INTO public."DeployJournal" (scriptname, applied)
+SELECT e.scriptname, NOW()
+FROM EdFiDeployJournal e
+LEFT JOIN public."DeployJournal" dj
+    ON e.ScriptName = dj.scriptname
+WHERE dj.scriptname IS NULL;


### PR DESCRIPTION
New scripts were added to make sure the deploy journal table would include scripts that were part of the change tracking feature. Previous work was done in #39 to add the infrastructure to the test base to make sure these were validated, so the only thing needed for this was to add the scripts themselves and confirm the tests work.